### PR TITLE
feature: add reefs and continuousReefing

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,18 @@ module.exports = function(app) {
               type: "number",
               title: "The maximum wind speed this sail can be used with, in m/s",
             },
+            reefs: {
+              type: "array",
+              title: "Reefed sail areas",
+              description: "In descending order, leave empty if no fixed reefs",
+              items: {
+                type: "number",
+              }
+            },
+            continuousReefing: {
+              type: "boolean",
+              title: "The sail can be reefed continuously, with no discreet steps"
+            },
             reducedState: {
               title: "Reefing state",
               type: 'object',


### PR DESCRIPTION
For a UI to present useful widgets for slab reefing (with discrete reefs) and continuous reefing like a roller furler it needs to know about the sail's reefing system. This is separate from the current reefing state.

<img width="772" alt="image" src="https://user-images.githubusercontent.com/1049678/208247869-39d351f9-5941-40ae-8e82-23d4cab7b80b.png">
